### PR TITLE
Missing manifest.json on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
 		"32",
 		"32@2x",
 		"128",
-		"svg"
+		"svg",
+		"manifest.json"
 	],
 	"keywords": [
 		"cryptocurrency",


### PR DESCRIPTION
We are missing the manifest.json file when installing the dependency using NPM. Can you release this fix in a `0.9.1`? Thx!