### PR TITLE
add Figma Plugin to used by section of `Readme.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,6 @@ Thanks to [Christopher Downer](https://github.com/cjdowner) for starting this pr
 - [Crypto Tools](http://bunchoftext.com/apps/crypto-calculator) - Cryptocurrency icons for Crypto Tools macOS app
 - [Cryptocurrency Ticker](https://cryptocurrencyticker.xyz) - Cryptocurrency ticker for Windows and Linux Mint - Cinnamon
 - [Spot](http://spot-bitcoin.com) - Cryptocurrency wallet
+- [Figma Plugin](https://www.figma.com/community/plugin/1170720285035693761) - Figma Plugin for Cryptocurrency Icons
 
 <sub>We're always happy to see where, and how these icons are used. Feel free to share your creations with us, and we will put you in this list.</sub>


### PR DESCRIPTION
I've quickly gathered together a Figma plugin to make it available for designers. It takes all 4 variants of the icons provided by this repo and offers them as components inside Figma. 

The repo is here: https://github.com/0xA3K5/crypto-icons-figma-plugin
The Figma plugin page (approved): https://www.figma.com/community/plugin/1170720285035693761

Thank you for this library. I'd like to help out updating some of the icons as well.